### PR TITLE
feat #85 Make secret deletion watch optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ Sidecar implementation which is used to copy K8s secret content into local files
     * name.pattern - naming pattern of the target file, supporting [golang template](https://pkg.go.dev/text/template) syntax. If *single* is set, this will be used as target *directory* pattern for the single files.
     * property.pattern - (optional) property base path to map the secret content under, supporting [golang template](https://pkg.go.dev/text/template) syntax
   * key.transformation - (optional) transformation function for the keys in the secret; one of [ToCamel|ToLowerCamel|ToKebab|ToScreamingKebab|ToSnake|ToScreamingSnake]
+  * deletion.watch - (optional) if set to *true*, sidecar will watch for secret deletion and drop their content from the
+  file-system as well. Note that **should not be used** at the moment, as this implementation currently adds finalizers
+  to secrets, which will not get removed.
 
 ## Examples
 
@@ -128,5 +131,5 @@ which will create by default a *jaconi.io/secret-file-provider:latest* image.
 ## Open Issues
 
 * Deletion case 
-  * secret deletion might be missed, if secret gets deleted completely between two reconciles
-  * single file deletion currently not supported
+  * When using approach with finalizers, those will get stuck forever if the pod is just terminated, as 
+  there is no cleanup logic in place

--- a/pkg/env/bootstrap.go
+++ b/pkg/env/bootstrap.go
@@ -19,6 +19,7 @@ func Bootstrap(rootCmd *cobra.Command) {
 	rootCmd.Flags().String(SecretNameSelector, "", "secret name pattern to consider")
 	rootCmd.Flags().String(SecretContentSelector, "", "secret content path to copy")
 	rootCmd.Flags().String(SecretKeyTransformation, "", "transformation function for all secret keys")
+	rootCmd.Flags().Bool(SecretDeletionWatch, false, "set to 'true' if secret deletion should be watched and therefore their content needs to be dropped from FS")
 	rootCmd.Flags().Bool(SecretFileSingle, false, "set to 'true' if each secret key should get it's own file")
 	rootCmd.Flags().String(SecretFileNamePattern, "", "target filename pattern")
 	rootCmd.Flags().String(SecretFilePropertyPattern, "", "base property path in target file")

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -22,6 +22,8 @@ const (
 
 	SecretKeyTransformation = "secret.key.transformation"
 
+	SecretDeletionWatch = "secret.deletion.watch"
+
 	CallbackMethod      = "callback.method"
 	CallbackUrl         = "callback.url"
 	CallbackBody        = "callback.body"


### PR DESCRIPTION
This PR addresses the fact, that the sidecar implementation will always add finalizers to a secret but might never drop them.

To overcome this, this quickfix will make the deletion watch (and therefore the finalizer attachment) optional. 

The new default behaviour is, that the sidecar will not watch for secret deletions and therefore will not add finalizers to the secrets.

This behaviour can be overwritten vie setting *secret.deletion.watch=true*