### PR TITLE
fix: apply key transformation only to secret keys

### DIFF
--- a/pkg/controllers/secrets/secret.go
+++ b/pkg/controllers/secrets/secret.go
@@ -33,11 +33,27 @@ import (
 //	  }
 //	}
 func readSecretContent(secret *corev1.Secret) map[interface{}]interface{} {
-	// fetch templates to potentially apply
-	selectorTemplate := viper.GetString(env.SecretContentSelector)
 	propertyPattern := viper.GetString(env.SecretFilePropertyPattern)
 
-	// store content information either as map or as plain string, depending on selector
+	mapContent, stringContent := extractContent(secret)
+
+	// if no additional properties: put content into plain map
+	if len(propertyPattern) < 1 {
+		if stringContent == "" {
+			// no nesting required, no plain content -> we are done at this point and
+			// can return the already read in map
+			return mapContent
+		}
+		return processSingleElement(stringContent)
+	}
+
+	return nestAdditionalProperties(secret, mapContent, stringContent)
+}
+
+// extractContent stores content information either as map or as plain string, depending on selector
+func extractContent(secret *corev1.Secret) (map[interface{}]interface{}, string) {
+	selectorTemplate := viper.GetString(env.SecretContentSelector)
+
 	mapContent := make(map[interface{}]interface{})
 	stringContent := ""
 
@@ -45,45 +61,49 @@ func readSecretContent(secret *corev1.Secret) map[interface{}]interface{} {
 	if len(selectorTemplate) < 1 {
 		// put all into map
 		for k, v := range secret.Data {
-			mapContent[k] = string(v)
+			mapContent[transform(k)] = string(v)
 		}
 	} else if !strings.Contains(selectorTemplate, "{{") {
 		// not a go template, log warning and put all into map
 		slog.Warn("illegal selector pattern; expecting go template", "pattern", selectorTemplate)
 		for k, v := range secret.Data {
-			mapContent[k] = string(v)
+			mapContent[transform(k)] = string(v)
 		}
 	} else {
 		// resolve template to string; do not put into map, as this is intended to be a plain string
 		stringContent = templates.Resolve(selectorTemplate, secret)
 	}
+	return mapContent, stringContent
+}
 
-	// if no additional properties: put content into plain map
-	if len(propertyPattern) < 1 {
+// processSingleElement creates a map containing only the given string value as value and the last
+// path segment of the content selector as key
+func processSingleElement(stringContent string) map[interface{}]interface{} {
+	selectorTemplate := viper.GetString(env.SecretContentSelector)
 
-		if stringContent == "" {
-			// no nesting required, no plain content -> we are done at this point and
-			// can return the already read in map
-			return mapContent
-		}
-
-		if len(selectorTemplate) < 1 {
-			// illegal configuration, should never happen
-			slog.Warn("single value but no selector found", "namespace", secret.Namespace, "name", secret.Name)
-			return make(map[interface{}]interface{})
-		}
-
-		// use last path segment of selector as key for the new map
-		key := selectorTemplate
-		if strings.Contains(selectorTemplate, ".") {
-			parts := strings.Split(selectorTemplate, ".")
-			key = parts[len(parts)-1]
-			// remove tailing braces
-			key = strings.Replace(key, "}", "", -1)
-		}
-		return map[interface{}]interface{}{key: stringContent}
+	if len(selectorTemplate) < 1 {
+		// illegal configuration, should never happen
+		slog.Warn("single value but no selector found")
+		return make(map[interface{}]interface{})
 	}
 
+	// use last path segment of selector as key for the new map
+	key := selectorTemplate
+	if strings.Contains(selectorTemplate, ".") {
+		parts := strings.Split(selectorTemplate, ".")
+		key = parts[len(parts)-1]
+		// remove tailing braces
+		key = strings.Replace(key, "}", "", -1)
+		// make sure the key (refering to secret key) is transformed if necessary
+		key = transform(key)
+	}
+	return map[interface{}]interface{}{key: stringContent}
+}
+
+// nestAdditionalProperties will attach either the given map- or string-content to a mandatory property pattern
+// prefix, gotten via [env.SecretFilePropertyPattern].
+func nestAdditionalProperties(secret *corev1.Secret, mapContent map[interface{}]interface{}, stringContent string) map[interface{}]interface{} {
+	propertyPattern := viper.GetString(env.SecretFilePropertyPattern)
 	propertyPath := templates.Resolve(propertyPattern, secret)
 
 	result := make(map[interface{}]interface{})
@@ -107,4 +127,12 @@ func readSecretContent(secret *corev1.Secret) map[interface{}]interface{} {
 		}
 	}
 	return result
+}
+
+func transform(key string) string {
+	transform := viper.GetString(env.SecretKeyTransformation)
+	if function, ok := keyTransformFunctions[transform]; ok {
+		return function(key)
+	}
+	return key
 }

--- a/pkg/controllers/secrets/secret_test.go
+++ b/pkg/controllers/secrets/secret_test.go
@@ -31,13 +31,23 @@ func TestReadSecretContent_wholeContent(t *testing.T) {
 	result := readSecretContent(secret)
 	g.Expect(result).To(gomega.Equal(map[interface{}]interface{}{"key1": "value1", "key2": "value2"}))
 
+	// with key transformation
+	viper.Set(env.SecretKeyTransformation, "ToCamel")
+	result = readSecretContent(secret)
+	g.Expect(result).To(gomega.Equal(map[interface{}]interface{}{"Key1": "value1", "Key2": "value2"}))
+
 	// with simple property path
 	viper.Set(env.SecretFilePropertyPattern, "foo")
 	result = readSecretContent(secret)
-	g.Expect(result).To(gomega.Equal(map[interface{}]interface{}{"foo": map[interface{}]interface{}{"key1": "value1", "key2": "value2"}}))
+	g.Expect(result).To(gomega.Equal(map[interface{}]interface{}{"foo": map[interface{}]interface{}{"Key1": "value1", "Key2": "value2"}}))
 
 	// with templated property path
 	viper.Set(env.SecretFilePropertyPattern, "{{.ObjectMeta.Labels.foo}}")
+	result = readSecretContent(secret)
+	g.Expect(result).To(gomega.Equal(map[interface{}]interface{}{"bar": map[interface{}]interface{}{"Key1": "value1", "Key2": "value2"}}))
+
+	// and now again without key transformation
+	viper.Set(env.SecretKeyTransformation, "")
 	result = readSecretContent(secret)
 	g.Expect(result).To(gomega.Equal(map[interface{}]interface{}{"bar": map[interface{}]interface{}{"key1": "value1", "key2": "value2"}}))
 }
@@ -63,6 +73,11 @@ func TestReadSecretContent_singleSelect(t *testing.T) {
 	// attach on root level
 	result := readSecretContent(secret)
 	g.Expect(result).To(gomega.Equal(map[interface{}]interface{}{"key1": "value1"}))
+
+	// with key transformation
+	viper.Set(env.SecretKeyTransformation, "ToCamel")
+	result = readSecretContent(secret)
+	g.Expect(result).To(gomega.Equal(map[interface{}]interface{}{"Key1": "value1"}))
 
 	// with simple property path
 	viper.Set(env.SecretFilePropertyPattern, "foo")

--- a/pkg/controllers/secrets/secrets_controller.go
+++ b/pkg/controllers/secrets/secrets_controller.go
@@ -104,13 +104,10 @@ func remove(secret *corev1.Secret) error {
 	// 2. read content from secret
 	newContent := readSecretContent(secret)
 
-	// 3. convert keys if necessary
-	convertedKeyMap := maps.TransformKeys(newContent, viper.GetString(env.SecretKeyTransformation))
+	// 3. drop new entries from existing map
+	resultingMap := maps.Drop(existingContent, newContent)
 
-	// 4. drop new entries from existing map
-	resultingMap := maps.Drop(existingContent, convertedKeyMap)
-
-	// 5. write to file
+	// 4. write to file
 	return file.WriteAll(log, f, resultingMap)
 }
 
@@ -127,12 +124,9 @@ func add(secret *corev1.Secret) error {
 	// 2. read content from secret
 	newContent := readSecretContent(secret)
 
-	// 3. convert keys if necessary
-	convertedKeyMap := maps.TransformKeys(newContent, viper.GetString(env.SecretKeyTransformation))
+	// 3. merge maps
+	resultingMap := maps.Union(existingContent, newContent)
 
-	// 4. merge maps
-	resultingMap := maps.Union(existingContent, convertedKeyMap)
-
-	// 5. write to file
+	// 4. write to file
 	return file.WriteAll(log, f, resultingMap)
 }

--- a/pkg/controllers/secrets/transform.go
+++ b/pkg/controllers/secrets/transform.go
@@ -1,0 +1,24 @@
+package secrets
+
+import (
+	"strings"
+
+	"github.com/iancoleman/strcase"
+)
+
+var keyTransformFunctions = map[string]func(string) string{
+	"ToCamel":          toCamel,
+	"ToLowerCamel":     toLowerCamel,
+	"ToKebab":          strcase.ToKebab,
+	"ToScreamingKebab": strcase.ToScreamingKebab,
+	"ToSnake":          strcase.ToSnake,
+	"ToScreamingSnake": strcase.ToScreamingSnake,
+}
+
+func toCamel(val string) string {
+	return strcase.ToCamel(strings.ToLower(val))
+}
+
+func toLowerCamel(val string) string {
+	return strcase.ToLowerCamel(strings.ToLower(val))
+}

--- a/pkg/controllers/secrets/transform_test.go
+++ b/pkg/controllers/secrets/transform_test.go
@@ -1,0 +1,25 @@
+package secrets
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestToCamel(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	g.Expect(toCamel("UhH_OHH")).To(Equal("UhhOhh"))
+	g.Expect(toCamel("UHH-OHH")).To(Equal("UhhOhh"))
+	g.Expect(toCamel("UHH-ohh")).To(Equal("UhhOhh"))
+	g.Expect(toCamel("uHH-ohh")).To(Equal("UhhOhh"))
+}
+
+func TestToLowerCamel(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	g.Expect(toLowerCamel("UhH_OHH")).To(Equal("uhhOhh"))
+	g.Expect(toLowerCamel("UHH-OHH")).To(Equal("uhhOhh"))
+	g.Expect(toLowerCamel("UHH-ohh")).To(Equal("uhhOhh"))
+	g.Expect(toLowerCamel("uHH-ohh")).To(Equal("uhhOhh"))
+}

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -11,15 +11,23 @@ const (
 	PortMetrics     = "port.metrics"
 	PortDebug       = "port.debug"
 
-	SecretLabelSelector     = "secret.selector.label"
-	SecretNameSelector      = "secret.selector.name"
+	// K8s label selector
+	SecretLabelSelector = "secret.selector.label"
+	// K8s secret name selector
+	SecretNameSelector = "secret.selector.name"
+	// K8s namespace selector
 	SecretNamespaceSelector = "secret.selector.namespace"
-	SecretContentSelector   = "secret.selector.content"
+	// read only a specific field of the whole secret data
+	SecretContentSelector = "secret.selector.content"
 
-	SecretFileSingle          = "secret.file.single"
-	SecretFileNamePattern     = "secret.file.name.pattern"
+	// true, if all secrets should be contained by a single file
+	SecretFileSingle = "secret.file.single"
+	// pattern for secret file names
+	SecretFileNamePattern = "secret.file.name.pattern"
+	// pattern for a secret property prefix
 	SecretFilePropertyPattern = "secret.file.property.pattern"
 
+	// transformation function for (K8s secret) keys
 	SecretKeyTransformation = "secret.key.transformation"
 
 	SecretDeletionWatch = "secret.deletion.watch"

--- a/pkg/maps/maps.go
+++ b/pkg/maps/maps.go
@@ -1,22 +1,5 @@
 package maps
 
-import (
-	"fmt"
-	"log/slog"
-	"os"
-
-	"github.com/iancoleman/strcase"
-)
-
-var KeyTransformFunctions = map[string]func(string) string{
-	"ToCamel":          ToCamel,
-	"ToLowerCamel":     ToLowerCamel,
-	"ToKebab":          strcase.ToKebab,
-	"ToScreamingKebab": strcase.ToScreamingKebab,
-	"ToSnake":          strcase.ToSnake,
-	"ToScreamingSnake": strcase.ToScreamingSnake,
-}
-
 // Union will merge two given maps recursive, where the values of the 'right' one will overwrite the ones
 // from the 'left'.
 func Union(left, right map[interface{}]interface{}) map[interface{}]interface{} {
@@ -75,33 +58,6 @@ func Copy(origin map[interface{}]interface{}) map[interface{}]interface{} {
 	out := make(map[interface{}]interface{}, len(origin))
 	for k, v := range origin {
 		out[k] = v
-	}
-	return out
-}
-
-// TransformKeys will transform all keys in the given map recursively with the given transform function,
-// which must exist in the 'KeyTransformFunctions' map.
-func TransformKeys(origin map[interface{}]interface{}, transform string) map[interface{}]interface{} {
-	if transform == "" {
-		return origin
-	}
-	if function, ok := KeyTransformFunctions[transform]; ok {
-		return transformKeysInt(origin, function)
-	}
-	slog.Error("illegal transform function", "function", transform)
-	os.Exit(1)
-	return nil
-}
-
-func transformKeysInt(origin map[interface{}]interface{}, transform func(string) string) map[interface{}]interface{} {
-	out := make(map[interface{}]interface{}, len(origin))
-	for k, v := range origin {
-		strKey := fmt.Sprintf("%v", k)
-		if vmap, ok := v.(map[interface{}]interface{}); ok {
-			out[transform(strKey)] = transformKeysInt(vmap, transform)
-		} else {
-			out[transform(strKey)] = v
-		}
 	}
 	return out
 }

--- a/pkg/maps/maps_test.go
+++ b/pkg/maps/maps_test.go
@@ -111,11 +111,3 @@ func TestUnion(t *testing.T) {
 
 	g.Expect(result).To(Equal(expectedResult))
 }
-
-func TestToCamel(t *testing.T) {
-	g := NewGomegaWithT(t)
-
-	g.Expect(ToCamel("UhH_OHH")).To(Equal("UhhOhh"))
-	g.Expect(ToCamel("UHH-OHH")).To(Equal("UhhOhh"))
-	g.Expect(ToCamel("UHH-ohh")).To(Equal("UhhOhh"))
-}


### PR DESCRIPTION
Applies key transformation function only to the secret key (and not the whole property path anymore)