### PR TITLE
refactor: maps package

### DIFF
--- a/pkg/maps/maps.go
+++ b/pkg/maps/maps.go
@@ -1,12 +1,16 @@
 package maps
 
+import (
+	gomaps "maps"
+)
+
 // Union will merge two given maps recursive, where the values of the 'right' one will overwrite the ones
 // from the 'left'.
 func Union(left, right map[interface{}]interface{}) map[interface{}]interface{} {
-	out := Copy(left)
+	out := gomaps.Clone(left)
 	for k, v := range right {
-		// If you use map[string]interface{}, ok is always false here.
-		// Because yaml.Unmarshal will give you map[interface{}]interface{}.
+		// If you use map[string]interface{}, ok is always false here, because [yaml.Unmarshal] returns
+		// map[interface{}]interface{}.
 		if v, ok := v.(map[interface{}]interface{}); ok {
 			if bv, ok := out[k]; ok {
 				if bv, ok := bv.(map[interface{}]interface{}); ok {
@@ -22,8 +26,7 @@ func Union(left, right map[interface{}]interface{}) map[interface{}]interface{} 
 
 // Drop will remove known entries from a given map recursively.
 func Drop(origin, toRemove map[interface{}]interface{}) map[interface{}]interface{} {
-
-	out := Copy(origin)
+	out := gomaps.Clone(origin)
 	for k, v := range toRemove {
 		if _, ok := out[k]; !ok {
 			// not existing, don't need to care
@@ -50,14 +53,6 @@ func Drop(origin, toRemove map[interface{}]interface{}) map[interface{}]interfac
 	}
 	if len(out) < 1 {
 		return nil
-	}
-	return out
-}
-
-func Copy(origin map[interface{}]interface{}) map[interface{}]interface{} {
-	out := make(map[interface{}]interface{}, len(origin))
-	for k, v := range origin {
-		out[k] = v
 	}
 	return out
 }

--- a/pkg/maps/maps_test.go
+++ b/pkg/maps/maps_test.go
@@ -24,6 +24,7 @@ func TestDrop(t *testing.T) {
 			"key21": "value21",
 		},
 		"key3": "value3",
+		"key4": "value4",
 	}
 	toDrop := map[interface{}]interface{}{
 		"key1": map[interface{}]interface{}{
@@ -34,6 +35,8 @@ func TestDrop(t *testing.T) {
 			},
 		},
 		"key2": "value2",
+		"key4": map[interface{}]interface{}{},
+		"key5": "value5",
 	}
 
 	expectedResult := map[interface{}]interface{}{

--- a/pkg/maps/string_transform.go
+++ b/pkg/maps/string_transform.go
@@ -1,4 +1,3 @@
-// As strcase.ToCamel does not work for SCREAMING_SNAKE input, we need our own function here
 package maps
 
 import (
@@ -7,10 +6,12 @@ import (
 	"github.com/iancoleman/strcase"
 )
 
+// ToCamel wraps [strcase.ToCamel], adding support for SCREAMING_SNAKE input.
 func ToCamel(val string) string {
 	return strcase.ToCamel(strings.ToLower(val))
 }
 
+// ToLowerCamel wraps [strcase.ToLowerCamel], adding support for SCREAMING_SNAKE input.
 func ToLowerCamel(val string) string {
 	return strcase.ToLowerCamel(strings.ToLower(val))
 }

--- a/pkg/maps/string_transform_test.go
+++ b/pkg/maps/string_transform_test.go
@@ -1,0 +1,25 @@
+package maps_test
+
+import (
+	"testing"
+
+	. "github.com/jaconi-io/secret-file-provider/pkg/maps"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestToCamel(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	g.Expect(ToCamel("")).To(BeEmpty())
+	g.Expect(ToCamel("foo")).To(Equal("Foo"))
+	g.Expect(ToCamel("FOO_BAR")).To(Equal("FooBar"))
+}
+
+func TestToLowerCamel(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	g.Expect(ToLowerCamel("")).To(BeEmpty())
+	g.Expect(ToLowerCamel("foo")).To(Equal("foo"))
+	g.Expect(ToLowerCamel("FOO_BAR")).To(Equal("fooBar"))
+}


### PR DESCRIPTION
- Use Go [maps.Clone](https://pkg.go.dev/maps#Clone) instead of custom method.
- Bring test coverage to 100%.
- Improve documentation of string transformations.